### PR TITLE
SaveAssociated always returns validation error

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2494,10 +2494,13 @@ class Model extends Object implements CakeEventListener {
 				$return[$association] = $validates;
 			}
 
-			if ($validates && !($this->create(null) !== null && $this->save($data, array('atomic' => false) + $options))) {
+			$saveResult = $this->save($data, array('atomic' => false) + $options);
+
+			if ($validates && !($this->create(null) !== null && $saveResult)) {
 				$validationErrors[$this->alias] = $this->validationErrors;
 				$validates = false;
 			}
+
 			$return[$this->alias] = $validates;
 
 			foreach ($data as $association => $values) {


### PR DESCRIPTION
The condition that checks directly against the function outcome (this->save) fails on some situations but works properly when assigning it to a variable and performing the condition using the variable instead. This fix should be propagated to earlier versions (happened on cake 2.4, 2.5 and 2.6 using PHP 5.5.9)
